### PR TITLE
Make imports more ergonomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It has been created with the intention of adding this data to the economy menu o
 
 By doing:
 ```python
-from fear_greed_index.CNNFearAndGreedIndex import CNNFearAndGreedIndex
+from fear_greed_index import CNNFearAndGreedIndex
 
 cnn_fg = CNNFearAndGreedIndex()
 

--- a/fear_greed_index/__init__.py
+++ b/fear_greed_index/__init__.py
@@ -1,0 +1,7 @@
+from .CNNFearAndGreedIndex import CNNFearAndGreedIndex
+from .FearAndGreedIndicator import FearAndGreedIndicator
+
+__all__ = [
+    "CNNFearAndGreedIndex",
+    "FearAndGreedIndicator",
+]


### PR DESCRIPTION
By importing names into `__init__.py` and then listing them in `__all__`, we can make it so users don't have to type so much and also make the imports look nicer.

Now instead of 

```python
from fear_greed_index.CNNFearAndGreedIndex import CNNFearAndGreedIndex
```

you can just type

```python
from fear_greed_index import CNNFearAndGreedIndex
```